### PR TITLE
set extended: true for bodyParser.urlencoded

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,7 +23,6 @@ const appName = settings.app_name || "homework-bet-dev";
 
 app.set('view engine', 'ejs');
 app.use(express.static('public'));
-app.use(bodyParser.urlencoded( {extended: false} ));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(session({


### PR DESCRIPTION
There are two lines for setting the bodyParser and it was breaking the ability to parse form-data from POST requests.