### PR TITLE
validating start / end dates in CourseModel

### DIFF
--- a/models/CourseModel.js
+++ b/models/CourseModel.js
@@ -21,7 +21,6 @@ const courseSchema = Schema({
 courseSchema.pre('save', function(next) {
     
     if( this.startDate > this.endDate ) {
-        console.log("course date mismatch found");
         next( new Error('Course end date must be greater than course start date!') );
         return;
     }

--- a/models/CourseModel.js
+++ b/models/CourseModel.js
@@ -18,22 +18,15 @@ const courseSchema = Schema({
  * pre-save error checker
  */
 
-/*
-courseSchema.pre('save', function() {
+courseSchema.pre('save', function(next) {
     
-    console.log("pre-save validation...");
-
     if( this.startDate > this.endDate ) {
-
         console.log("course date mismatch found");
-        next( new Error('Course end date must be greater than course start date!'));
+        next( new Error('Course end date must be greater than course start date!') );
         return;
     }
-
     next();
-
 });
-*/
 
 const CourseModel = mongoose.model('Course', courseSchema);
 module.exports = CourseModel;

--- a/routes/courses.js
+++ b/routes/courses.js
@@ -33,6 +33,7 @@ router.post('/', (req, res) => {
         res.redirect('/users/' + String(course.user._id));
     }).catch(err => {
         console.log(err);
+        res.redirect('courses/new');
     });
 });
 

--- a/routes/courses.js
+++ b/routes/courses.js
@@ -24,7 +24,7 @@ router.get('/new', function (req, res) {
 });
 
 router.post('/', (req, res) => {
-    UserModel.findById(req.body.userId).exec()
+    UserModel.findById(req.body.userId)
     .then(user => {
         const courseData = req.body.course;
         courseData.user = user;
@@ -33,7 +33,7 @@ router.post('/', (req, res) => {
         res.redirect('/users/' + String(course.user._id));
     }).catch(err => {
         console.log(err);
-        res.redirect('courses/new');
+        res.redirect('/courses/new');
     });
 });
 

--- a/routes/courses.js
+++ b/routes/courses.js
@@ -24,16 +24,15 @@ router.get('/new', function (req, res) {
 });
 
 router.post('/', (req, res) => {
-    UserModel.findById(req.body.userId)
+    UserModel.findById(req.body.userId).exec()
     .then(user => {
         const courseData = req.body.course;
-        courseData.user = user
+        courseData.user = user;
         return CourseModel.create(courseData);
     }).then(course => {
         res.redirect('/users/' + String(course.user._id));
     }).catch(err => {
         console.log(err);
-        res.redirect('/courses/new');
     });
 });
 

--- a/tests/CourseModel.js
+++ b/tests/CourseModel.js
@@ -5,6 +5,7 @@ const assert = chai.assert;
 const expect = chai.expect;
 const settings = require('../app_settings.json');
 
+const moment = require('moment');
 const UserModel = require('../models/UserModel');
 const UserFactory = require('../factories/User');
 const CourseModel = require('../models/CourseModel');
@@ -41,17 +42,36 @@ describe('Course Model Tests', function () {
         });
     }),
 
-        it('Course with no user fails to save.', function (done) {
-            const courseData = CourseFactory.random({});
-            const course = new CourseModel(courseData);
+    it('Course with no user fails to save.', function (done) {
+        const courseData = CourseFactory.random({});
+        const course = new CourseModel(courseData);
 
-            CourseModel.create(courseData).then(function (course) {
-                console.log("Saved invalid course!");
-                assert();
-            }).catch(function (err) {
-                done();
-            });
-        }),
+        CourseModel.create(courseData).then(function (course) {
+            console.log("Saved invalid course!");
+            assert();
+        }).catch(function (err) {
+            done();
+        });
+    }),
+
+    it("shouldn't save a course with endDate preceeding startDate", () => {
+        const userData = UserFactory.random();
+        const courseData = CourseFactory.random({});
+        
+        courseData.startDate = moment().add(1, 'days');
+        courseData.endDate = moment();
+
+        return UserModel.create(userData)
+        .then((user) => {
+            courseData.user = user;
+            return CourseModel.create(courseData)
+        }).then(() => {
+            console.log("Course with invalid dates was saved.");
+            assert(false)
+        }, (err) => {
+            assert(true)
+        });
+    }),
 
     after(function (done) {
         mongoose.connection.db.dropDatabase(function () {


### PR DESCRIPTION
Addresses #17 - adds validation to CourseModel to enforce that start date must precede end date.

Separating course name / number and adding an institution were deemed unnecessary as the course only has meaning to the user. 

Currently, the user is just redirected to courses/new on failure.