### PR TITLE
added pool factory, added unit test to confirm functionality

### DIFF
--- a/factories/Pool.js
+++ b/factories/Pool.js
@@ -6,5 +6,13 @@ module.exports = {
             startDate: moment(),
             endDate: moment().add(3, 'months'),
         }
+    },
+    generateYear: (year) => {
+        return [
+            {startDate: new Date(year, 0, 1), endDate: new Date(year, 2, 31)},
+            {startDate: new Date(year,3, 1), endDate: new Date(year, 5, 30)},
+            {startDate: new Date(year, 6, 1), endDate: new Date(year, 8, 30)},
+            {startDate: new Date(year, 9, 1), endDate: new Date(year, 11, 31)},
+        ];
     }
 }

--- a/tests/PoolFactory.js
+++ b/tests/PoolFactory.js
@@ -1,0 +1,23 @@
+const chai = require('chai');
+const assert = chai.assert;
+const expect = chai.expect;
+
+const PoolFactory = require('../factories/Pool');
+
+describe('PoolFactory Tests', () => {
+    it('should generate a list of pool start/end dates for 2018', () => {
+        pooldates = PoolFactory.generateYear(2018);
+
+        assert(pooldates[0].startDate.getTime() === (new Date(2018, 0, 1)).getTime());
+        assert(pooldates[0].endDate.getTime() === (new Date(2018, 2, 31)).getTime());
+
+        assert(pooldates[1].startDate.getTime() === (new Date(2018, 3, 1)).getTime());
+        assert(pooldates[1].endDate.getTime() === (new Date(2018, 5, 30)).getTime());
+
+        assert(pooldates[2].startDate.getTime() === (new Date(2018, 6, 1)).getTime());
+        assert(pooldates[2].endDate.getTime() === (new Date(2018, 8, 30)).getTime());
+
+        assert(pooldates[3].startDate.getTime() === (new Date(2018, 9, 1)).getTime());
+        assert(pooldates[3].endDate.getTime() === (new Date(2018, 11, 31)).getTime());
+    });
+});

--- a/tests/PoolModel.js
+++ b/tests/PoolModel.js
@@ -26,7 +26,7 @@ describe('Pool Model Tests', function () {
             console.log('mongoose: connected to ' + dbUrl);
             done();
         });
-    }),
+    })
 
     it('should save a valid pool to the database.', () => {
         const poolData = PoolFactory.random();
@@ -36,7 +36,7 @@ describe('Pool Model Tests', function () {
             assert.equal(Date(pool.startDate), Date(poolData.startDate));
             assert.equal(Date(pool.endDate), Date(pool.endDate));
         });
-    });
+    })
 
     it('should hold a course.', () => {
         const userData = UserFactory.random();
@@ -60,8 +60,22 @@ describe('Pool Model Tests', function () {
             assert.equal(course.startDate, courseData.startDate);
             assert.equal(course.endDate, courseData.endDate);
         });
+    })
 
-    });
+    it('should work with PoolFactory.generateYear()', () => {
+        poolDataArray = PoolFactory.generateYear(2018)
+        const promises = poolDataArray.map(poolData => PoolModel.create(poolData))
+
+        return Promise.all(promises).then(pools => {
+            assert(pools.length === 4);
+            
+            pools.forEach(pool => {
+                assert.equal(String(pool._id).length, 24)
+                assert(pool.startDate instanceof Date)
+                assert(pool.endDate instanceof Date)
+            });
+        });
+    })
 
     after(function (done) {
         mongoose.connection.db.dropDatabase(function () {

--- a/tests/PoolModel.js
+++ b/tests/PoolModel.js
@@ -62,6 +62,23 @@ describe('Pool Model Tests', function () {
         });
     });
 
+    it('should generate a list of pool start/end dates for 2018', () => {
+        pooldates = PoolFactory.generateYear(2018);
+
+        assert(pooldates[0].startDate.getTime() === (new Date(2018, 0, 1)).getTime() );
+        assert(pooldates[0].endDate.getTime() === (new Date(2018, 2, 31)).getTime() );
+
+        assert(pooldates[1].startDate.getTime() === (new Date(2018, 3, 1)).getTime() );
+        assert(pooldates[1].endDate.getTime() === (new Date(2018, 5, 30)).getTime() );
+
+        assert(pooldates[2].startDate.getTime() === (new Date(2018, 6, 1)).getTime() );
+        assert(pooldates[2].endDate.getTime() === (new Date(2018, 8, 30)).getTime() );
+
+        assert(pooldates[3].startDate.getTime() === (new Date(2018, 9, 1)).getTime() );
+        assert(pooldates[3].endDate.getTime() === (new Date(2018, 11, 31)).getTime() );
+
+    });
+
     after(function (done) {
         mongoose.connection.db.dropDatabase(function () {
             mongoose.connection.close(done);

--- a/tests/PoolModel.js
+++ b/tests/PoolModel.js
@@ -60,22 +60,6 @@ describe('Pool Model Tests', function () {
             assert.equal(course.startDate, courseData.startDate);
             assert.equal(course.endDate, courseData.endDate);
         });
-    });
-
-    it('should generate a list of pool start/end dates for 2018', () => {
-        pooldates = PoolFactory.generateYear(2018);
-
-        assert(pooldates[0].startDate.getTime() === (new Date(2018, 0, 1)).getTime() );
-        assert(pooldates[0].endDate.getTime() === (new Date(2018, 2, 31)).getTime() );
-
-        assert(pooldates[1].startDate.getTime() === (new Date(2018, 3, 1)).getTime() );
-        assert(pooldates[1].endDate.getTime() === (new Date(2018, 5, 30)).getTime() );
-
-        assert(pooldates[2].startDate.getTime() === (new Date(2018, 6, 1)).getTime() );
-        assert(pooldates[2].endDate.getTime() === (new Date(2018, 8, 30)).getTime() );
-
-        assert(pooldates[3].startDate.getTime() === (new Date(2018, 9, 1)).getTime() );
-        assert(pooldates[3].endDate.getTime() === (new Date(2018, 11, 31)).getTime() );
 
     });
 


### PR DESCRIPTION
Added a factory to create a pool for the given year, with dates hard-coded for now. 

Added a test in /tests/PoolModel to confirm that this works for a sample year 2018. 