### PR TITLE
fix user model password hashing bug and add unit test to confirm passwords are hashed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+ - "node"

--- a/factories/Course.js
+++ b/factories/Course.js
@@ -40,7 +40,6 @@ const createRandomWithThisUser = (user) => {
     
     return CourseModel.create(courseData)
     .then(course => {
-        console.log(`Added ${user.email} to course: ${course._id}`)
         return Promise.resolve(course)
     }).catch(err => {
         return Promise.reject("Course not created.")

--- a/factories/User.js
+++ b/factories/User.js
@@ -29,7 +29,6 @@ const random = () => {
 
 const createRandom = () => {
     const userData = random()
-    console.log(`Creating ${userData.email} with password ${userData.password}`)
     return UserModel.create(userData);
 }
 

--- a/models/UserModel.js
+++ b/models/UserModel.js
@@ -26,30 +26,30 @@ const userSchema = mongoose.Schema({
  * adapted from devsmash.com/blog/password-authentication-with-mongoose-and-bcrypt
  */
 
-userSchema.pre('save', function(next) {
+userSchema.pre('save', function (next) {
     var user = this;
-        
-    if( user.isModified('password') ) {
-        // generate salt
-        bcrypt.genSalt( SALT_WORK_FACTOR, function(err, salt) {
-            if(err) {
-                return next(err);
-            } 
 
-            // hash password 
-            bcrypt.hash(user.password, salt, function(err, hash) {
-                if(err) { 
-                    return next(err);
-                }
-
-                // finally, override password with hash
-                user.password = hash;
-                next();
-            });
-        });
+    if (!user.isModified('password')) {
+        return next()
     }
 
-    return next()
+    // generate salt
+    bcrypt.genSalt(SALT_WORK_FACTOR, function (err, salt) {
+        if (err) {
+            return next(err);
+        }
+
+        // hash password 
+        bcrypt.hash(user.password, salt, function (err, hash) {
+            if (err) {
+                return next(err);
+            }
+
+            // finally, override password with hash
+            user.password = hash;
+            next();
+        });
+    });
 });
 
 

--- a/tests/UserModel.js
+++ b/tests/UserModel.js
@@ -95,7 +95,19 @@ describe('User Model Tests', function() {
             assert.equal(courses[0].name, course.name);
             assert.equal(String(courses[0]._id), String(course._id));
         });
-    }),
+    })
+
+    it('should hash passwords', () => {
+        const userData = UserFactory.random();
+        
+        return UserModel.create(userData)
+        .then(user => {
+            assert.notEqual(userData.password, user.password)
+            assert(user.password.length === 59 || user.password.length === 60,
+                "Password hash should be 59 or 60 chars.")
+            assert.include(user.password, "$2a$", "Password hash should have $2a$")
+        })
+    })
 
     // TODO: check on this test to make sure it isn't evergreen
     it('should register with valid credentials', function(done) {


### PR DESCRIPTION
- fixed pre-save bug in `models/UserModel.js`
- added a unit test to verify that users are being saved with hashed passwords

functionally, these two should be equivalent, but the bottom way was working locally on my Mac and breaking on c9 (linux). I reverted it back to the top way.

```
// inside models/UserModel.js, working version
if(!passwordModified) {
   return next();
}
// do password hashing
```
```
// inside models/UserModel.js, non-working version
if(passwordModified) {
   // do password hashing
}
return next();
```
  